### PR TITLE
internal/imports: initial implementation

### DIFF
--- a/_test/httpapp/server.go
+++ b/_test/httpapp/server.go
@@ -31,6 +31,7 @@ func main() {
 	http.HandleFunc("/formatDate", h.makeHandler("formatDate", h.handleFormatDate))
 	http.HandleFunc("/jsonInspect", h.makeHandler("jsonInspect", h.handleJsonInspect))
 	http.HandleFunc("/validateIdent", h.makeHandler("validateIdent", h.handleValidateIdent))
+	http.HandleFunc("/objectsSum", h.makeHandler("objectsSum", h.handleObjectsSum))
 
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }
@@ -178,5 +179,33 @@ func (h *appHandler) handleValidateIdent(w http.ResponseWriter, req *http.Reques
 
 	w.Write([]byte("OK\n"))
 
+	return nil
+}
+
+type bigObject struct {
+	str  string
+	x    int
+	y    int
+	data [512]byte
+}
+
+var bigObjectList []bigObject
+
+func init() {
+	for i := 0; i < 3000; i++ {
+		bigObjectList = append(bigObjectList, bigObject{
+			str: fmt.Sprintf("[%d]", i),
+			x:   i,
+			y:   i * 2,
+		})
+	}
+}
+
+func (h *appHandler) handleObjectsSum(w http.ResponseWriter, req *http.Request) error {
+	sum := 0
+	for _, obj := range bigObjectList {
+		sum += obj.x + obj.y
+	}
+	fmt.Fprintf(w, "sum=%d", sum)
 	return nil
 }

--- a/_test/httpapp/wrk/main.go
+++ b/_test/httpapp/wrk/main.go
@@ -21,6 +21,7 @@ func main() {
 		"stats":              1,
 		"jsonInspect":        4,
 		"validateIdentError": 4,
+		"objectsSum":         5,
 		"validateIdent":      10,
 		"formatDate":         15,
 	}
@@ -53,6 +54,8 @@ func main() {
 					doValidateIdent(true)
 				case "validateIdentError":
 					doValidateIdent(false)
+				case "objectsSum":
+					doObjectsSum()
 				}
 				delayRand := rand.Intn(150)
 				if delayRand >= 140 {
@@ -102,4 +105,8 @@ func doValidateIdent(valid bool) {
 	} else {
 		getRequest("http://localhost:8080/validateIdent?arg=This_Is_InvalidThis_Is_InvalidThis_Is_InvalidThis_Is_InvalidThis_Is_InvalidThis_Is_Invalid")
 	}
+}
+
+func doObjectsSum() {
+	getRequest("http://localhost:8080/objectsSum")
 }

--- a/go.mod
+++ b/go.mod
@@ -5,16 +5,18 @@ go 1.17
 require (
 	github.com/cespare/subcmd v1.1.0
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd
-	github.com/quasilyte/go-ruleguard v0.3.15-0.20220101152245-3db0900f752c
+	github.com/quasilyte/go-ruleguard v0.3.15-0.20220103111154-4538cb2a0fd5
 	github.com/quasilyte/go-ruleguard/dsl v0.3.12-0.20220101152245-3db0900f752c
 	github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8
-	golang.org/x/tools v0.1.8
+	golang.org/x/tools v0.1.9-0.20211228192929-ee1ca4ffc4da
 )
 
 require (
 	github.com/go-toolsmith/astcopy v1.0.0 // indirect
 	github.com/go-toolsmith/astequal v1.0.1 // indirect
-	github.com/quasilyte/gogrep v0.0.0-20220101011336-1fa18c9834d9 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
+	github.com/quasilyte/go-ruleguard/rules v0.0.0-20220103111154-4538cb2a0fd5 // indirect
+	github.com/quasilyte/gogrep v0.0.0-20220103110004-ffaa07af02e3 // indirect
 	golang.org/x/mod v0.5.1 // indirect
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,7 @@ github.com/google/pprof v0.0.0-20211214055906-6f57359322fd h1:1FjCyPC+syAzJ5/2S8
 github.com/google/pprof v0.0.0-20211214055906-6f57359322fd/go.mod h1:KgnwoLYCZ8IQu3XUZ8Nc/bM9CCZFOyjUNOSygVozoDg=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/quasilyte/go-ruleguard v0.3.1-0.20210203134552-1b5a410e1cc8/go.mod h1:KsAh3x0e7Fkpgs+Q9pNLS5XpFSvYCEVl5gP9Pp1xp30=
+github.com/quasilyte/go-ruleguard v0.3.13/go.mod h1:Ul8wwdqR6kBVOCt2dipDBkE+T6vAV/iixkrKuRTN1oQ=
 github.com/quasilyte/go-ruleguard v0.3.15-0.20211230090521-10dc4ed7b0f0 h1:OcGZAZURCFSvR5Ywer+So7WHygq1AdkOrH5Cd2jwv4E=
 github.com/quasilyte/go-ruleguard v0.3.15-0.20211230090521-10dc4ed7b0f0/go.mod h1:gP9bl2y/36TTgBhQ/FkixCBAcDIsen29DSlJ2N9rMrk=
 github.com/quasilyte/go-ruleguard v0.3.15-0.20220101014345-135dd93114a0 h1:9hZfFf3dgSrWlrYd2LYsrhe3a+5A7uyBiaQKnRZ0bos=
@@ -25,6 +26,8 @@ github.com/quasilyte/go-ruleguard v0.3.15-0.20220101143450-184fad673365 h1:p885l
 github.com/quasilyte/go-ruleguard v0.3.15-0.20220101143450-184fad673365/go.mod h1:iUN7q2EDtdPfAiKzTnsauSaJXJFAFBwPbP74EFPpVJs=
 github.com/quasilyte/go-ruleguard v0.3.15-0.20220101152245-3db0900f752c h1:r1H+5ut4RBa6/uQ98CkzjHQL5+GLtLxjoxAmdpPUAXA=
 github.com/quasilyte/go-ruleguard v0.3.15-0.20220101152245-3db0900f752c/go.mod h1:WgxpUYthrZcG8TsTIEri6DMfxkac4Na6ybt4bRt4mUo=
+github.com/quasilyte/go-ruleguard v0.3.15-0.20220103111154-4538cb2a0fd5 h1:G45mNyQcj4zAGo/3fk1J0V21cxIHTeG05Beh8sVzCtY=
+github.com/quasilyte/go-ruleguard v0.3.15-0.20220103111154-4538cb2a0fd5/go.mod h1:NhuWhnlVEM1gT1A4VJHYfy9MuYSxxwHgxWoPsn9llB4=
 github.com/quasilyte/go-ruleguard/dsl v0.3.0/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/dsl v0.3.10/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/dsl v0.3.11-0.20211230090521-10dc4ed7b0f0 h1:xgCBH2ow4sLih8enTC7c6v54ZSpwXWLutMeG/JE4IO8=
@@ -38,12 +41,17 @@ github.com/quasilyte/go-ruleguard/dsl v0.3.12-0.20220101150716-969a394a9451/go.m
 github.com/quasilyte/go-ruleguard/dsl v0.3.12-0.20220101152245-3db0900f752c h1:IcFVEsXH0FqqZpuKhLwIvXUC0ggg5/tMATU50RTAr30=
 github.com/quasilyte/go-ruleguard/dsl v0.3.12-0.20220101152245-3db0900f752c/go.mod h1:KeCP03KrjuSO0H1kTuZQCWlQPulDV6YMIXmpQss17rU=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20201231183845-9e62ed36efe1/go.mod h1:7JTjp89EGyU1d6XfBiXihJNG37wB2VRkd125Q1u7Plc=
+github.com/quasilyte/go-ruleguard/rules v0.0.0-20210428214800-545e0d2e0bf7/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
 github.com/quasilyte/go-ruleguard/rules v0.0.0-20211022131956-028d6511ab71/go.mod h1:4cgAphtvu7Ftv7vOT2ZOYhC6CvBxZixcasr8qIOTA50=
+github.com/quasilyte/go-ruleguard/rules v0.0.0-20220103111154-4538cb2a0fd5 h1:gbgMC6cXzUzNhzpfzeOZCgn5VTzhxuExpESwktrlmXs=
+github.com/quasilyte/go-ruleguard/rules v0.0.0-20220103111154-4538cb2a0fd5/go.mod h1:qcky+2J9aJ/Ab0sq6bczUS8V+U8peQ9M4Ay+Hipy4HQ=
 github.com/quasilyte/gogrep v0.0.0-20211226113550-e12a97c7d96d/go.mod h1:wSEyW6O61xRV6zb6My3HxrQ5/8ke7NE2OayqCHa3xRM=
 github.com/quasilyte/gogrep v0.0.0-20211228112733-26cfd4290aa3 h1:qk9TgAI3IN6pgYB+M7K/RZodJDBcyIUm/wL1/clGBng=
 github.com/quasilyte/gogrep v0.0.0-20211228112733-26cfd4290aa3/go.mod h1:wSEyW6O61xRV6zb6My3HxrQ5/8ke7NE2OayqCHa3xRM=
 github.com/quasilyte/gogrep v0.0.0-20220101011336-1fa18c9834d9 h1:p9cFHH+qZyszd3CATUUMXRwKAqKJuVtasWdgzI+Yrpk=
 github.com/quasilyte/gogrep v0.0.0-20220101011336-1fa18c9834d9/go.mod h1:wSEyW6O61xRV6zb6My3HxrQ5/8ke7NE2OayqCHa3xRM=
+github.com/quasilyte/gogrep v0.0.0-20220103110004-ffaa07af02e3 h1:P4QPNn+TK49zJjXKERt/vyPbv/mCHB/zQ4flDYOMN+M=
+github.com/quasilyte/gogrep v0.0.0-20220103110004-ffaa07af02e3/go.mod h1:wSEyW6O61xRV6zb6My3HxrQ5/8ke7NE2OayqCHa3xRM=
 github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8 h1:XTVqxdjLyMjPMSOaHFsjIqeu1EeUensbK97c2I29In8=
 github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8/go.mod h1:mPJZP5qrgK90IzVVdmPOOJhTXyy65WoldUR1QPeh6AU=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
@@ -84,6 +92,8 @@ golang.org/x/tools v0.0.0-20200812195022-5ae4c3c160a0/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20201230224404-63754364767c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.8 h1:P1HhGGuLW4aAclzjtmJdf0mJOjVUZUzOTqkAkWL+l6w=
 golang.org/x/tools v0.1.8/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
+golang.org/x/tools v0.1.9-0.20211228192929-ee1ca4ffc4da h1:Tno72dYE94v/7SyyIj9iBsc7OOjFu2PyNcl7yxxeZD8=
+golang.org/x/tools v0.1.9-0.20211228192929-ee1ca4ffc4da/go.mod h1:nABZi5QlRsZVlzPpHl034qft6wpY4eDcsTt5AaioBiU=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/imports/fix_test.go
+++ b/internal/imports/fix_test.go
@@ -1,0 +1,271 @@
+package imports
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFix(t *testing.T) {
+	tests := []struct {
+		before string
+		after  string
+	}{
+		// Add a single import to a file without imports.
+		{`
+package example
+
+func f() string {
+	return strings.Repeat("foo", 2)
+}`, `
+package example
+
+import (
+	"strings"
+)
+
+func f() string {
+	return strings.Repeat("foo", 2)
+}`,
+		},
+
+		// Add two imports to a file without imports.
+		{`
+package example
+
+func f() string {
+	return strings.Repeat("foo", 2)
+}
+func g() []byte {
+	return bytes.Repeat([]byte("foo"), 2)
+}`, `
+package example
+
+import (
+	"bytes"
+	"strings"
+)
+
+func f() string {
+	return strings.Repeat("foo", 2)
+}
+func g() []byte {
+	return bytes.Repeat([]byte("foo"), 2)
+}`,
+		},
+
+		// Add two imports to a file with imports in () group.
+		{`
+package example
+
+import (
+	"io"
+)
+
+func f(r io.Reader) (string, []byte) {
+	return strings.Repeat("foo", 2),
+           bytes.Repeat(nil, 2)
+}`, `
+package example
+
+import (
+	"io"
+	"bytes"
+	"strings"
+)
+
+func f(r io.Reader) (string, []byte) {
+	return strings.Repeat("foo", 2),
+           bytes.Repeat(nil, 2)
+}`,
+		},
+
+		// Add two imports to a file with 1 unit import.
+		{`
+package example
+
+import "io"
+
+func f(r io.Reader) (string, []byte) {
+	return strings.Repeat("foo", 2),
+           bytes.Repeat(nil, 2)
+}`, `
+package example
+
+import (
+	"io"
+	"bytes"
+	"strings"
+)
+
+func f(r io.Reader) (string, []byte) {
+	return strings.Repeat("foo", 2),
+           bytes.Repeat(nil, 2)
+}`,
+		},
+
+		// Add one import to a file with 1 unit import.
+		{`
+package example
+
+import "io"
+
+func f(r io.Reader) string {
+	return strings.Repeat("foo", 2)
+}`, `
+package example
+
+import (
+	"io"
+	"strings"
+)
+
+func f(r io.Reader) string {
+	return strings.Repeat("foo", 2)
+}`,
+		},
+
+		// Add and remove one.
+		{`
+package example
+
+import "io"
+
+func f() string { return strings.Repeat("foo", 2)
+}`, `
+package example
+
+import (
+	"strings"
+)
+
+func f() string { return strings.Repeat("foo", 2)
+}`,
+		},
+
+		// Removed all imports.
+		{`
+package example
+
+import "io"
+
+func f() string { return "" }`, `
+package example
+
+
+func f() string { return "" }`,
+		},
+
+		// Removed all imports.
+		{`
+package example
+
+import "io"
+
+import "bytes"
+
+func f() string { return "" }`, `
+package example
+
+
+
+func f() string { return "" }`,
+		},
+
+		// Removed all imports.
+		{`
+package example
+
+import "io"
+import "bytes"
+
+func f() string { return "" }`, `
+package example
+
+
+func f() string { return "" }`,
+		},
+
+		// Removed all imports.
+		{`
+package example
+
+import ("io")
+import ("bytes")
+
+func f() string { return "" }`, `
+package example
+
+
+func f() string { return "" }`,
+		},
+
+		// Removed all imports.
+		{`
+package example
+
+import (
+	"io"
+)
+import (
+	"bytes"
+)
+
+func f() string { return "" }`, `
+package example
+
+
+func f() string { return "" }`,
+		},
+
+		// Removed two, added one.
+		{`
+package example
+
+import (
+	"io"
+)
+import (
+	"bytes"
+)
+
+func f() int { return rand.Intn(10) }`, `
+package example
+
+import (
+	"math/rand"
+)
+
+func f() int { return rand.Intn(10) }`,
+		},
+	}
+
+	for i := range tests {
+		test := tests[i]
+		t.Run(fmt.Sprintf("test%d", i), func(t *testing.T) {
+			config := FixConfig{
+				StdlibPackages: map[string]string{
+					"strings": "strings",
+					"bytes":   "bytes",
+					"rand":    "math/rand",
+				},
+			}
+			fixed, err := Fix(config, []byte(test.before))
+			if err != nil {
+				t.Fatal(err)
+			}
+			have := string(bytes.TrimSpace(fixed))
+			want := strings.TrimSpace(test.after)
+			if diff := cmp.Diff(have, want); diff != "" {
+				t.Errorf("results mismatches (+want -have):\n%s", diff)
+				fmt.Println("Before:")
+				fmt.Println(test.before)
+				fmt.Println("After:")
+				fmt.Println(have)
+			}
+		})
+	}
+}

--- a/internal/imports/fixer.go
+++ b/internal/imports/fixer.go
@@ -1,0 +1,166 @@
+package imports
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path"
+	"sort"
+	"strconv"
+)
+
+type fixer struct {
+	config FixConfig
+}
+
+func newFixer(config FixConfig) *fixer {
+	return &fixer{
+		config: config,
+	}
+}
+
+func (f *fixer) Fix(src []byte) ([]byte, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "", src, parser.ParseComments)
+	if err != nil {
+		return nil, err
+	}
+
+	var importDecls []*ast.GenDecl
+	imports := make(map[string]string, 8)
+	usages := make(map[string]struct{}, 8)
+	var walkError error
+	ast.Inspect(file, func(n ast.Node) bool {
+		if n == nil {
+			return false
+		}
+		switch n := n.(type) {
+		case *ast.GenDecl:
+			if n.Tok != token.IMPORT {
+				return true
+			}
+			importDecls = append(importDecls, n)
+
+		case *ast.ImportSpec:
+			importedPath, err := strconv.Unquote(n.Path.Value)
+			if err != nil {
+				walkError = fmt.Errorf("unquote %q: %w", n.Path.Value, err)
+			}
+			var localName string
+			if n.Name != nil {
+				localName = n.Name.Name
+			} else {
+				localName = path.Base(importedPath)
+			}
+			imports[localName] = importedPath
+
+		case *ast.SelectorExpr:
+			xident, ok := n.X.(*ast.Ident)
+			if !ok {
+				return true
+			}
+			if xident.Obj != nil {
+				// If the parser can resolve it, it's not a package ref.
+				return true
+			}
+			pkgName := xident.Name
+			usages[pkgName] = struct{}{}
+		}
+		return true
+	})
+	if walkError != nil {
+		return nil, walkError
+	}
+
+	var missingImports []string
+	for pkgName := range usages {
+		pkgPath := f.config.Packages[pkgName]
+		if pkgPath == "" {
+			pkgPath = f.config.StdlibPackages[pkgName]
+		}
+		if pkgPath == "" {
+			continue
+		}
+		missingImports = append(missingImports, pkgPath)
+	}
+	sort.Strings(missingImports)
+
+	unusedImports := make(map[string]struct{})
+	for pkgName, pkgPath := range imports {
+		if pkgName == "_" || pkgName == "." {
+			continue
+		}
+		if pkgPath == "C" {
+			continue
+		}
+		_, isUsed := usages[pkgName]
+		if !isUsed {
+			unusedImports[pkgPath] = struct{}{}
+		}
+	}
+
+	var buf bytes.Buffer
+	continueFrom := 0
+	if len(imports) != 0 {
+		startFrom := 0
+		for i, decl := range importDecls {
+			numUsedImports := 0
+			for _, spec := range decl.Specs {
+				spec := spec.(*ast.ImportSpec)
+				importedPath, _ := strconv.Unquote(spec.Path.Value)
+				if _, ok := unusedImports[importedPath]; !ok {
+					numUsedImports++
+				}
+			}
+			insertImports := i == 0 && len(missingImports) != 0
+			isEmpty := !insertImports && numUsedImports == 0
+			continueFrom = fset.Position(decl.End()).Offset
+			if isEmpty {
+				buf.Write(src[startFrom:fset.Position(decl.Pos()).Offset])
+				if bytes.HasPrefix(src[continueFrom:], []byte("\n")) {
+					continueFrom++
+				} else if bytes.HasPrefix(src[continueFrom:], []byte("\r\n")) {
+					continueFrom += 2
+				}
+				startFrom = continueFrom
+				continue
+			}
+
+			buf.Write(src[startFrom : fset.Position(decl.Pos()).Offset+len("import")])
+			buf.WriteString(" (\n")
+			for _, spec := range decl.Specs {
+				spec := spec.(*ast.ImportSpec)
+				importedPath, _ := strconv.Unquote(spec.Path.Value)
+				if _, ok := unusedImports[importedPath]; ok {
+					continue
+				}
+				if spec.Name != nil {
+					fmt.Fprintf(&buf, "\t%s %s\n", spec.Name.Name, spec.Path.Value)
+				} else {
+					fmt.Fprintf(&buf, "\t%s\n", spec.Path.Value)
+				}
+			}
+			// Put extra imports into the first import decl.
+			if i == 0 {
+				for _, pkgPath := range missingImports {
+					fmt.Fprintf(&buf, "\t%q\n", pkgPath)
+				}
+			}
+			buf.WriteByte(')')
+			startFrom = continueFrom
+		}
+	} else {
+		buf.Write(src[:fset.Position(file.Name.End()).Offset+1])
+		buf.WriteString("\nimport (\n")
+		for _, pkgPath := range missingImports {
+			fmt.Fprintf(&buf, "\t%q\n", pkgPath)
+		}
+		buf.WriteString(")\n")
+		continueFrom = fset.Position(file.Name.End()).Offset + 1
+	}
+	buf.Write(src[continueFrom:])
+
+	return buf.Bytes(), nil
+}

--- a/internal/imports/imports.go
+++ b/internal/imports/imports.go
@@ -1,0 +1,21 @@
+package imports
+
+// Fix tries to fix imports from a Go file source code.
+//
+// It only works with src that can be parsed by a Go parser,
+// otherwise a parsing error will be returned.
+//
+// We perform these operations:
+//	1. Remove unused imports from a file.
+//	2. Add missing imports.
+//
+// It does not introduce any formatting changes, unless strictly necessary.
+func Fix(config FixConfig, src []byte) ([]byte, error) {
+	f := newFixer(config)
+	return f.Fix(src)
+}
+
+type FixConfig struct {
+	StdlibPackages map[string]string
+	Packages       map[string]string
+}


### PR DESCRIPTION
Package imports can try to fix the file imports.
It can insert missing imports and remove the unused ones.

It does not format the source code like fmt or goimports.