### PR TITLE
cmd/perfguard: report fixes that can't be applied

### DIFF
--- a/internal/quickfix/quickfix_test.go
+++ b/internal/quickfix/quickfix_test.go
@@ -31,7 +31,8 @@ func TestQuickFixNested(t *testing.T) {
 	}
 
 	runTest := func(want string, fixes []TextEdit) {
-		have := string(Apply([]byte(input), fixes))
+		out, _ := Apply([]byte(input), fixes)
+		have := string(out)
 		if have != want {
 			t.Errorf("%q %v:\nhave: `%s`\nwant: `%s`", input, fixes, have, want)
 		}
@@ -122,7 +123,8 @@ foo = $x ?
 
 	for s, replacements := range tests {
 		test := createTestCase(s, replacements)
-		have := string(Apply([]byte(test.input), test.fixes))
+		out, _ := Apply([]byte(test.input), test.fixes)
+		have := string(out)
 		if have != test.want {
 			t.Errorf("%q %q:\nhave: `%s`\nwant: `%s`", test.input, replacements, have, test.want)
 		}


### PR DESCRIPTION
If text edits are overlapping, we stay conservative and
apply only one of them.

To avoid the information loss, quickfixes that were not
actually applied will be reported normally.