### PR TITLE
perfguard/_rules: remove bundle

### DIFF
--- a/perfguard/_rules/universal_rules.go
+++ b/perfguard/_rules/universal_rules.go
@@ -4,8 +4,6 @@ import (
 	"github.com/quasilyte/go-ruleguard/dsl"
 )
 
-var Bundle = dsl.Bundle{}
-
 // Universal rules are shared in both `lint` and `optimize` modes.
 //
 // By default, all rules trigger on every successful match.


### PR DESCRIPTION
See https://github.com/quasilyte/go-ruleguard/issues/355

perfguard should not need that dependency when custom rules
are not used. This is why we're using rules embedding.