### PR TITLE
cmd/perfguard: fix single-file targets handling with heatmap

### DIFF
--- a/cmd/perfguard/runner.go
+++ b/cmd/perfguard/runner.go
@@ -188,7 +188,7 @@ func (r *runner) Run() error {
 			if _, ok := r.heatmapPackages[ref.name]; ok {
 				filtered = append(filtered, ref)
 			} else {
-				r.printDebugf("skip %s package", ref.path)
+				r.printDebugf("skip %s (%s) package", ref.name, ref.path)
 				numSkipped++
 			}
 		}
@@ -514,7 +514,11 @@ func (r *runner) findPackages(ctx context.Context, fset *token.FileSet, targets 
 	if len(pkgs) == 1 {
 		pkg := pkgs[0]
 		if pkg.PkgPath == "command-line-arguments" && len(targets) == 1 {
-			ref := packageRef{id: pkg.ID, path: targets[0]}
+			ref := packageRef{
+				id:   pkg.ID,
+				name: pkg.Name,
+				path: targets[0],
+			}
 			return []packageRef{ref}, nil
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/google/pprof v0.0.0-20211214055906-6f57359322fd
 	github.com/quasilyte/go-ruleguard v0.3.16-0.20220113092427-60b3b255b443
 	github.com/quasilyte/go-ruleguard/dsl v0.3.14-0.20220113092427-60b3b255b443
-	github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8
+	github.com/quasilyte/perf-heatmap v0.0.0-20220113135715-5506accae633
 	golang.org/x/tools v0.1.9-0.20220107172756-94bfe6897a14
 )
 

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/quasilyte/gogrep v0.0.0-20220104235416-e471a266cab5 h1:HJoZW+y9lDdp8P
 github.com/quasilyte/gogrep v0.0.0-20220104235416-e471a266cab5/go.mod h1:wSEyW6O61xRV6zb6My3HxrQ5/8ke7NE2OayqCHa3xRM=
 github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8 h1:XTVqxdjLyMjPMSOaHFsjIqeu1EeUensbK97c2I29In8=
 github.com/quasilyte/perf-heatmap v0.0.0-20211220153856-7361377975b8/go.mod h1:mPJZP5qrgK90IzVVdmPOOJhTXyy65WoldUR1QPeh6AU=
+github.com/quasilyte/perf-heatmap v0.0.0-20220113135715-5506accae633 h1:EIB7/hq0g4lSoRJ/umDxXu3rpaCL2O/CtWaMKIZ7w6g=
+github.com/quasilyte/perf-heatmap v0.0.0-20220113135715-5506accae633/go.mod h1:mPJZP5qrgK90IzVVdmPOOJhTXyy65WoldUR1QPeh6AU=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=


### PR DESCRIPTION
Updated perf-heatmap lib also simplifies nested function
handling, so we get #84 resolved for free.