### PR TITLE
perfguard/_rules: fix rangeValueCopy pos ranges

### DIFF
--- a/perfguard/_rules/opt_rules.go
+++ b/perfguard/_rules/opt_rules.go
@@ -74,7 +74,7 @@ func writeString2(m dsl.Matcher) {
 //doc:tags    o1 score2
 func rangeValueCopy(m dsl.Matcher) {
 	// TODO: move to a hand-written checker so we can provide a quickfix for this.
-	m.Match(`for $_, $v := range $_ { $*_ }`, `for $_, $v = range $_ { $*_ }`).
+	m.Match(`for $_, $v := range $_`, `for $_, $v = range $_`).
 		Where(m["v"].Type.Size > 128).
 		Report(`every iteration copies a large object into $v`)
 }

--- a/perfguard/rulesdata/opt_rules.go
+++ b/perfguard/rulesdata/opt_rules.go
@@ -250,8 +250,8 @@ var Opt = &ir.File{
 			Rules: []ir.Rule{{
 				Line: 77,
 				SyntaxPatterns: []ir.PatternString{
-					{Line: 77, Value: "for $_, $v := range $_ { $*_ }"},
-					{Line: 77, Value: "for $_, $v = range $_ { $*_ }"},
+					{Line: 77, Value: "for $_, $v := range $_"},
+					{Line: 77, Value: "for $_, $v = range $_"},
 				},
 				ReportTemplate: "every iteration copies a large object into $v",
 				WhereExpr: ir.FilterExpr{


### PR DESCRIPTION
Use a `range header` pattern instead of a whole loop `for ... {$*_}`
pattern that will use the whole loop body to compute the relevant
CPU profile samples.

With `range header`, we only calculate the first loop line, the one
that accounts for arguments copying.