### PR TITLE
perfguard/_rules: add math.Abs optimization rules

### DIFF
--- a/cmd/perfguard/testdata/rulestest/mathExpr/mathExpr.go
+++ b/cmd/perfguard/testdata/rulestest/mathExpr/mathExpr.go
@@ -1,0 +1,18 @@
+package rulestest
+
+import (
+	"math"
+)
+
+func Warn(x, y float64) {
+	_ = math.Abs(x) * math.Abs(y) // want `math.Abs(x) * math.Abs(y) => math.Abs((x) * (y))`
+	_ = math.Abs(x) / math.Abs(y) // want `math.Abs(x) / math.Abs(y) => math.Abs((x) / (y))`
+}
+
+func Ignore(x, y float64) {
+	_ = math.Abs(x * y)
+	_ = math.Abs(x / y)
+
+	_ = math.Abs(x) + math.Abs(y)
+	_ = math.Abs(x) - math.Abs(y)
+}

--- a/perfguard/_rules/universal_rules.go
+++ b/perfguard/_rules/universal_rules.go
@@ -942,3 +942,12 @@ func sliceLit(m dsl.Matcher) {
 	m.Match(`append([]$typ(nil), $x)`).Suggest(`[]$typ{$x}`)
 	m.Match(`append([]$typ(nil), $x, $*rest)`).Suggest(`[]$typ{$x, $rest}`)
 }
+
+//doc:summary Detects math package expressions that can be optimized
+//doc:tags    o1 score1
+//doc:before  math.Abs(x) * math.Abs(y)
+//doc:after   math.Abs(x * y)
+func mathExpr(m dsl.Matcher) {
+	m.Match(`math.Abs($x) * math.Abs($y)`).Suggest(`math.Abs(($x) * ($y))`)
+	m.Match(`math.Abs($x) / math.Abs($y)`).Suggest(`math.Abs(($x) / ($y))`)
+}

--- a/perfguard/rulesdata/universal_rules.go
+++ b/perfguard/rulesdata/universal_rules.go
@@ -4584,6 +4584,29 @@ var Universal = &ir.File{
 				},
 			},
 		},
+		{
+			Line:        950,
+			Name:        "mathExpr",
+			MatcherName: "m",
+			DocTags:     []string{"o1", "score1"},
+			DocSummary:  "Detects math package expressions that can be optimized",
+			DocBefore:   "math.Abs(x) * math.Abs(y)",
+			DocAfter:    "math.Abs(x * y)",
+			Rules: []ir.Rule{
+				{
+					Line:            951,
+					SyntaxPatterns:  []ir.PatternString{{Line: 951, Value: "math.Abs($x) * math.Abs($y)"}},
+					ReportTemplate:  "$$ => math.Abs(($x) * ($y))",
+					SuggestTemplate: "math.Abs(($x) * ($y))",
+				},
+				{
+					Line:            952,
+					SyntaxPatterns:  []ir.PatternString{{Line: 952, Value: "math.Abs($x) / math.Abs($y)"}},
+					ReportTemplate:  "$$ => math.Abs(($x) / ($y))",
+					SuggestTemplate: "math.Abs(($x) / ($y))",
+				},
+			},
+		},
 	},
 }
 


### PR DESCRIPTION
Add rewrite rules:

	math.Abs(x) * math.Abs(y) => math.Abs((x) * (y))
	math.Abs(x) / math.Abs(y) => math.Abs((x) / (y))

See https://github.com/golang/go/issues/50126